### PR TITLE
Use `env python3` shebang for portability

### DIFF
--- a/add-collab.py
+++ b/add-collab.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import requests
 import argparse

--- a/add-webhook.py
+++ b/add-webhook.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import requests
 import argparse

--- a/delete-webhook.py
+++ b/delete-webhook.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import requests
 import argparse

--- a/travis-webhook.py
+++ b/travis-webhook.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import requests
 import argparse


### PR DESCRIPTION
E.g. on OS X with Python 3 from Homebrew.
